### PR TITLE
Change the sponsor banner to PDFPeer

### DIFF
--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -1,11 +1,15 @@
-
 export const AnnouncementBanner = () => {
   return (
     <div className='banner'>
-      ✨ Deep dive in the world of AI with{' '}
+      ✨ Turn your documents to AI with{' '}
       <div className='link'>
-        <a href={'https://aitools.fyi/'} target='_blank'>
-          aitools.fyi
+        <a
+          href={
+            'https://pdfpeer.com?ref=youfy&utm_source=youfy&utm_medium=banner&utm_campaign=youfy'
+          }
+          target='_blank'
+        >
+          PDFPeer
         </a>
       </div>
     </div>


### PR DESCRIPTION
This PR replaces the sponsor on the top bar to PDFPeer from aitools.fyi